### PR TITLE
Update to KDE 6.6

### DIFF
--- a/com.obsproject.Studio.Plugin.OBSVkCapture.yml
+++ b/com.obsproject.Studio.Plugin.OBSVkCapture.yml
@@ -29,7 +29,7 @@ modules:
       - type: git
         url: https://github.com/nowrep/obs-vkcapture.git
         tag: v1.5.1
-        commit: 30ce606372263d818caa868e45ccefae0faac3c2
+        commit: 553fbb146a6902e58ac4fc1cd8e1d3e25dc98b0d
         x-checker-data:
           type: git
           is-main-source: true

--- a/com.obsproject.Studio.Plugin.OBSVkCapture.yml
+++ b/com.obsproject.Studio.Plugin.OBSVkCapture.yml
@@ -28,7 +28,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/nowrep/obs-vkcapture.git
-        tag: v1.5.0
+        tag: v1.5.1
         commit: 30ce606372263d818caa868e45ccefae0faac3c2
         x-checker-data:
           type: git

--- a/com.obsproject.Studio.Plugin.OBSVkCapture.yml
+++ b/com.obsproject.Studio.Plugin.OBSVkCapture.yml
@@ -2,7 +2,7 @@ id: com.obsproject.Studio.Plugin.OBSVkCapture
 branch: stable
 runtime: com.obsproject.Studio
 runtime-version: stable
-sdk: org.kde.Sdk//6.5
+sdk: org.kde.Sdk//6.6
 build-extension: true
 separate-locales: false
 appstream-compose: false

--- a/flathub.json
+++ b/flathub.json
@@ -1,6 +1,5 @@
 {
 	"only-arches": [ "x86_64" ],
 	"skip-icons-check": true,
-	"disable-external-data-checker": true,
-	"automerge-flathubbot-prs": true
+	"disable-external-data-checker": true
 }


### PR DESCRIPTION
OBS Studio is built against KDE 6.6 now and it also needs a rebuild for OBS 30.2.

fixes: #52 