### PR TITLE
Revert "Auto-merge after successful build"

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,6 +1,5 @@
 {
 	"only-arches": [ "x86_64" ],
 	"skip-icons-check": true,
-	"disable-external-data-checker": true,
-	"automerge-flathubbot-prs": true
+	"disable-external-data-checker": true
 }


### PR DESCRIPTION
Reverts flathub/com.obsproject.Studio.Plugin.OBSVkCapture#50

Feature was removed from flathub: https://docs.flathub.org/blog/linter-restricting-automatic-merge/